### PR TITLE
Disable CUB

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -3,6 +3,8 @@
 
 if [[ $CUDA_PATH ]]; then
     export CONDA_CUPY_CUDA_PATH=$CUDA_PATH
+    export CONDA_CUB_DISABLED=$CUB_DISABLED
 fi
 
 export CUDA_PATH=$CONDA_PREFIX
+export CUB_DISABLED=1

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -7,3 +7,10 @@ if [[ $CONDA_CUPY_CUDA_PATH ]]; then
 else
     unset CUDA_PATH
 fi
+
+if [[ $CONDA_CUB_DISABLED ]]; then
+    export CUB_DISABLED=$CONDA_CUB_DISABLED
+    unset CONDA_CUB_DISABLED
+else
+    unset CONDA_CUB_DISABLED
+fi


### PR DESCRIPTION
As we have some issues using CUB (and it is included by default in CUDA 11), just make sure CUB is disabled at runtime.

xref: https://github.com/cupy/cupy/issues/3822

cc @cjnolet @mike-wendt @raydouglass